### PR TITLE
Dark mode

### DIFF
--- a/adscore/templates/base-form.html
+++ b/adscore/templates/base-form.html
@@ -100,6 +100,7 @@
       </div>
     </div>
   </div>
+  <div id="darkSwitch" class="darkmode-toggle" title="Turn on dark mode">🌓</div>
 
   <script>
     function autocomplete(searchBox, autoValues) {


### PR DESCRIPTION
When opening an abstract page using page's url, the dark mode switch is missing.